### PR TITLE
fix: use user's preferred OCR language as default on upload page

### DIFF
--- a/frontend/src/components/Upload/UploadZone.tsx
+++ b/frontend/src/components/Upload/UploadZone.tsx
@@ -91,7 +91,7 @@ const UploadZone: React.FC<UploadZoneProps> = ({ onUploadComplete }) => {
         setSelectedLanguages([userLang]);
         setPrimaryLanguage(userLang);
       } catch {
-        // Fallback eng si l API echoue
+        // Fallback to `eng` as primary language
         setSelectedLanguages(['eng']);
         setPrimaryLanguage('eng');
       }


### PR DESCRIPTION
## Summary

The `UploadZone` component hardcodes `['eng']` as the default OCR language instead of fetching `current_user_language` from the `/api/ocr/languages` endpoint. Users who configured a different language (e.g. French) always see "English" on the upload page.

## Changes

- Import `ocrService` from the api module in `UploadZone.tsx`
- Initialize `selectedLanguages` and `primaryLanguage` as empty (instead of hardcoded `'eng'`)
- Add a `useEffect` hook on mount that calls `ocrService.getAvailableLanguages()` and sets the user's preferred language
- Fallback to `'eng'` if the API call fails

## Test plan

- [ ] Log in as a user with OCR language set to a non-English language (e.g. French)
- [ ] Navigate to the Upload page
- [ ] Verify the OCR language selector shows the user's preferred language (e.g. "French"), not "English"
- [ ] Upload a document and verify OCR processes in the correct language
- [ ] Log in as a user with no language preference set and verify it falls back to English